### PR TITLE
Add processor to reset styleCache. Fixes #26.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,14 @@
 'use strict';
 
-var Postcss = require('postcss');
+var postcss = require('postcss');
 
 var processors = {
     pluginFilter: function () {
-        return require('postcss-filter-plugins')({silent: true})
+        return require('postcss-filter-plugins')({silent: true});
     },
     discardComments: {fn: require('postcss-discard-comments'), ns: 'comments'},
     autoprefixer: {fn: require('autoprefixer-core'), ns: 'autoprefixer'},
     zindex: {fn: require('postcss-zindex'), ns: 'zindex'},
-    discardEmpty: require('postcss-discard-empty'),
     minifyFontWeight: require('postcss-minify-font-weight'),
     convertValues: require('postcss-convert-values'),
     calc: {fn: require('postcss-calc'), ns: 'calc'},
@@ -33,13 +32,15 @@ var processors = {
     discardDuplicates: require('postcss-discard-duplicates'),
     functionOptimiser: require('./lib/functionOptimiser'),
     mergeRules: {fn: require('postcss-merge-rules'), ns: 'merge'},
-    uniqueSelectors: require('postcss-unique-selectors')
+    discardEmpty: require('postcss-discard-empty'),
+    uniqueSelectors: require('postcss-unique-selectors'),
+    styleCache: require('./lib/styleCache')
 };
 
-var cssnano = Postcss.plugin('cssnano', function (options) {
+var cssnano = postcss.plugin('cssnano', function (options) {
     options = options || {};
 
-    var postcss = Postcss();
+    var proc = postcss();
     var plugins = Object.keys(processors);
     var len = plugins.length;
     var i = 0;
@@ -60,10 +61,10 @@ var cssnano = Postcss.plugin('cssnano', function (options) {
             }
             method = processor.fn;
         }
-        postcss.use(method(opts));
+        proc.use(method(opts));
     }
 
-    return postcss;
+    return proc;
 });
 
 module.exports = cssnano;
@@ -71,11 +72,11 @@ module.exports = cssnano;
 module.exports.process = function (css, options) {
     options = options || {};
     options.map = options.map || (options.sourcemap ? true : null);
-    var result = Postcss([cssnano(options)]).process(css, options);
+    var result = postcss([cssnano(options)]).process(css, options);
     // return a css string if inline/no sourcemap.
     if (options.map === null || options.map === true || (options.map && options.map.inline)) {
         return result.css;
     }
     // otherwise return an object of css & map
     return result;
-}
+};

--- a/lib/styleCache.js
+++ b/lib/styleCache.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var postcss = require('postcss');
+
+module.exports = postcss.plugin('cssnano-reset-stylecache', function () {
+    return function (css, result) {
+        result.root.styleCache = {
+            colon:         ':',
+            indent:        '',
+            beforeDecl:    '',
+            beforeRule:    '',
+            beforeOpen:    '',
+            beforeClose:   '',
+            beforeComment: '',
+            after:         '',
+            emptyBody:     '',
+            commentLeft:   '',
+            commentRight:  ''
+        };
+    };
+});

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "postcss-discard-comments": "^1.2.0",
     "postcss-discard-duplicates": "^1.1.3",
     "postcss-discard-empty": "^1.1.1",
-    "postcss-discard-unused": "^1.0.1",
+    "postcss-discard-unused": "^1.0.2",
     "postcss-filter-plugins": "^1.0.0",
     "postcss-font-family": "^1.2.0",
     "postcss-merge-idents": "^1.0.1",

--- a/tests/issue26.css
+++ b/tests/issue26.css
@@ -1,0 +1,17 @@
+@media print {
+    .test {
+        -webkit-border-radius: 0;
+        border-radius: 0;
+    }
+}
+
+@media print {
+    .test {
+        -webkit-box-shadow: none;
+        box-shadow: none;
+    }
+}
+
+.test {
+    width: 500px;
+}

--- a/tests/issue26.expected.css
+++ b/tests/issue26.expected.css
@@ -1,0 +1,1 @@
+@media print{.test{box-shadow:none;border-radius:0}}.test{width:500px}

--- a/tests/issue26.js
+++ b/tests/issue26.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var postcss = require('postcss');
+var cssnano = require('..');
+var fs = require('fs');
+var path = require('path');
+var test = require('tape');
+
+test('it should compress whitespace after node.clone()', function (t) {
+    t.plan(1);
+
+    var css = fs.readFileSync(path.join(__dirname, 'issue26.css'), 'utf-8');
+    var expected = fs.readFileSync(path.join(__dirname, 'issue26.expected.css'), 'utf-8');
+
+    var processor = postcss([
+      postcss.plugin('cloner', function () {
+        return function (css) {
+          css.eachAtRule(function (rule) {
+            css.prepend(rule.clone());
+            rule.removeSelf();
+          });
+        };
+      }),
+      cssnano()
+    ]);
+
+    processor.process(css).then(function (result) {
+      t.equal(result.css, expected);
+    });
+});


### PR DESCRIPTION
This should fix any whitespace issues when combining cssnano with PostCSS plugins that utilise `node.clone()`. Would be nice to get some confirmation.

/cc @meuwka @faergeek @benfrain @ai