### PR TITLE
Resolve a crash when using the safe option via wrapper plugin.

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,14 +65,19 @@ var safeOptions = {
         keyframes: false
     },
     postcssZindex: {
-      disable: true
+        disable: true
     }
 };
 
 var cssnano = postcss.plugin('cssnano', function (options) {
+    if (options && options.safe) {
+        options.isSafe = options.safe;
+        options.safe = null;
+    }
+
     options = options || {};
 
-    var safe = options.safe === true;
+    var safe = options.isSafe === true;
     var proc = postcss();
 
     if (typeof options.fontFamily !== 'undefined' || typeof options.minifyFontWeight !== 'undefined') {
@@ -100,9 +105,7 @@ var cssnano = postcss.plugin('cssnano', function (options) {
         );
 
         if (opts === false) {
-          opts = {
-            disable: true
-          };
+            opts = {disable: true};
         }
 
         opts = assign({},

--- a/tests/api.js
+++ b/tests/api.js
@@ -99,3 +99,13 @@ test('should disable features if the user specifies so (3)', function (t) {
         t.equal(result.css, min, specName('disableColourMinification'));
     });
 });
+
+test('should not fail when options.safe is enabled', function (t) {
+    var css = 'h1 { z-index: 100 }';
+    var min = 'h1{z-index:100}';
+
+    nano.process(css, {safe: true}).then(function (result) {
+        t.plan(1);
+        t.equal(result.css, min, specName('beConsumedByPostCSS'));
+    });
+});


### PR DESCRIPTION
Ref: https://github.com/ben-eb/cssnano/issues/84

I think it might be fine to re-assign the property internally, instead of changing the name.