### PR TITLE
Add optimiser for background position values.

### DIFF
--- a/src/__tests__/integrations.js
+++ b/src/__tests__/integrations.js
@@ -9,18 +9,13 @@ import frameworks from 'css-frameworks';
 
 const base = join(__dirname, 'integrations');
 
-function formatted (css) {
-    return postcss().use(nano()).use(formatter).process(css);
-}
-
 Object.keys(frameworks).forEach(framework => {
     const testName = 'produceTheExpectedResultFor: ' + framework + '.css';
     ava(framework + '.css', t => {
-        formatted(frameworks[framework]).then(result => {
+        const plugins = [nano(), formatter()];
+        return postcss(plugins).process(frameworks[framework]).then(result => {
             const expected = file(join(base, framework) + '.css', 'utf-8');
             t.same(result.css, expected, specName(testName));
-        }, err => {
-            t.notOk(err.stack);
         });
     });
 });

--- a/src/__tests__/integrations/basscss5.css
+++ b/src/__tests__/integrations/basscss5.css
@@ -291,11 +291,11 @@ input[type=range]{vertical-align:middle;background-color:transparent}
 .button-transparent.is-disabled,.button-transparent:disabled{opacity:.5}
 .bg-cover{background-size:cover}
 .bg-contain{background-size:contain}
-.bg-center{background-position:center}
+.bg-center{background-position:50%}
 .bg-top{background-position:top}
-.bg-right{background-position:right}
+.bg-right{background-position:100%}
 .bg-bottom{background-position:bottom}
-.bg-left{background-position:left}
+.bg-left{background-position:0}
 .border{border:1px solid rgba(0,0,0,.125)}
 .border-top{border-top-style:solid;border-top-width:1px;border-top-color:rgba(0,0,0,.125)}
 .border-right{border-right-style:solid;border-right-width:1px;border-right-color:rgba(0,0,0,.125)}

--- a/src/__tests__/modules/cssnano-reduce-positions.js
+++ b/src/__tests__/modules/cssnano-reduce-positions.js
@@ -1,0 +1,112 @@
+module.exports.name = 'cssnano/reduce-positions';
+
+let tests = module.exports.tests = [];
+
+const directions = ['top', 'right', 'bottom', 'left', 'center'];
+const horizontal = {
+    right: '100%',
+    left: '0'
+};
+
+const vertical = {
+    bottom: '100%',
+    top: '0'
+};
+
+const hkeys = Object.keys(horizontal);
+const vkeys = Object.keys(vertical);
+
+const decls = [{
+    property: 'background-position:',
+    additional: ''
+}, {
+    property: 'background:',
+    additional: '#000 url(cat.jpg) '
+}];
+
+decls.forEach(({additional, property}) => {
+    const push = ({message, fixture, expected}) => {
+        tests.push({
+            message: message,
+            fixture: `${property}${additional}` + fixture,
+            expected: `${property}${additional}` + expected
+        });
+        tests.push({
+            message: message + ' (with multiple arguments)',
+            fixture: `${property}${additional}` + fixture + ', ' + fixture,
+            expected: `${property}${additional}` + expected + ',' + expected
+        });
+    };
+    if (property === 'background:') {
+        push({
+            message: 'should convert <percentage> center/50% 50% to <percentage>/50% 50%',
+            fixture: '30% center/50% 50%',
+            expected: '30%/50% 50%'
+        });
+    }
+    push({
+        message: 'should convert <percentage> center to <percentage>',
+        fixture: `30% center`,
+        expected: `30%`
+    });
+    push({
+        message: 'should not convert <percentage> <percentage>',
+        fixture: `45% 60%`,
+        expected: `45% 60%`
+    });
+    directions.forEach(direction => {
+        let conversion = horizontal[direction] || direction;
+        if (direction === 'center') {
+            conversion = '50%';
+        }
+        if (direction === 'right' || direction === 'left' || direction === 'center') {
+            push({
+                message: `should convert "${direction}" to "${conversion}"`,
+                fixture: `${direction}`,
+                expected: `${conversion}`
+            });
+        }
+        push({
+            message: `should convert "${direction} center" to "${conversion}"`,
+            fixture: `${direction} center`,
+            expected: `${conversion}`
+        });
+        if (direction === 'center') {
+            return;
+        }
+        push({
+            message: `should convert "center ${direction}" to "${conversion}"`,
+            fixture: `center ${direction}`,
+            expected: `${conversion}`
+        });
+        directions.slice(0, -1).filter(d => {
+            if (
+                d === direction ||
+                (~hkeys.indexOf(d) && ~hkeys.indexOf(direction)) ||
+                (~vkeys.indexOf(d) && ~vkeys.indexOf(direction)) 
+            ) {
+                return false;
+            }
+            return true;
+        }).forEach(other => {
+            let result;
+            if (~Object.keys(horizontal).indexOf(direction)) {
+                result = horizontal[direction] + ' ' + vertical[other];
+            } else {
+                result = horizontal[other] + ' ' + vertical[direction];
+            }
+            push({
+                message: `should convert "${direction} ${other}" to "${result}"`,
+                fixture: `${direction} ${other}`,
+                expected: `${result}`
+            });
+            if (property === 'background:') {
+                push({
+                    message: `should convert "${direction} ${other}"/50% 50% to "${result}/50% 50%"`,
+                    fixture: `${direction} ${other}/50% 50%`,
+                    expected: `${result}/50% 50%`
+                });
+            }
+        });
+    });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ import postcssDiscardUnused from 'postcss-discard-unused';
 import postcssNormalizeUrl from 'postcss-normalize-url';
 import functionOptimiser from './lib/functionOptimiser';
 import filterOptimiser from './lib/filterOptimiser';
+import reducePositions from './lib/reducePositions';
 import core from './lib/core';
 import postcssMergeIdents from 'postcss-merge-idents';
 import postcssReduceIdents from 'postcss-reduce-idents';
@@ -57,6 +58,7 @@ let processors = {
     postcssNormalizeUrl: postcssNormalizeUrl,
     functionOptimiser: functionOptimiser,
     filterOptimiser: filterOptimiser,
+    reducePositions: reducePositions,
     core: core,
     // Optimisations after this are sensitive to previous optimisations in
     // the pipe, such as whitespace normalising/selector re-ordering

--- a/src/lib/reducePositions.js
+++ b/src/lib/reducePositions.js
@@ -1,0 +1,112 @@
+import {plugin} from 'postcss';
+import valueParser, {unit} from 'postcss-value-parser';
+
+const directions = ['top', 'right', 'bottom', 'left', 'center'];
+const properties = [
+    'background',
+    'background-position'
+];
+
+const horizontal = {
+    right: '100%',
+    left: '0'
+};
+
+const vertical = {
+    bottom: '100%',
+    top: '0'
+};
+
+const hkeys = Object.keys(horizontal);
+const vkeys = Object.keys(vertical);
+
+function getArguments (node) {
+    return node.nodes.reduce((list, child) => {
+        if (child.type !== 'div') {
+            list[list.length - 1].push(child);
+        } else {
+            list.push([]);
+        }
+        return list;
+    }, [[]]);
+}
+
+function transform (decl) {
+    if (!~properties.indexOf(decl.prop)) {
+        return;
+    }
+    const values = valueParser(decl.value);
+    const args = getArguments(values);
+    const relevant = [];
+    args.forEach(arg => {
+        relevant.push({
+            start: null,
+            end: null
+        });
+        arg.forEach((part, index) => {
+            let isPosition = ~directions.indexOf(part.value) || unit(part.value);
+            if (relevant[relevant.length - 1].start === null && isPosition) {
+                relevant[relevant.length - 1].start = index;
+                return;
+            }
+            if (relevant[relevant.length - 1].start !== null && (part.type === 'space' || isPosition)) {
+                relevant[relevant.length - 1].end = index;
+                return;
+            }
+        });
+    });
+    relevant.forEach((range, index) => {
+        if (range.start === null) {
+            return;
+        }
+        const position = args[index].slice(range.start, (range.end || args[index].length) + 1);
+        if (position.length > 3) {
+            return;
+        }
+        if (position.length === 1 || position[2].value === 'center') {
+            if (position[2]) {
+                position[2].value = position[1].value = '';
+            }
+            if (position[0].value === 'right') {
+                position[0].value = '100%';
+                return;
+            }
+            if (position[0].value === 'left') {
+                position[0].value = '0';
+                return;
+            }
+            if (position[0].value === 'center') {
+                position[0].value = '50%';
+                return;
+            }
+            return;
+        }
+        if (position[0].value === 'center' && ~directions.indexOf(position[2].value)) {
+            position[0].value = position[1].value = '';
+            if (position[2].value === 'right') {
+                position[2].value = '100%';
+                return;
+            }
+            if (position[2].value === 'left') {
+                position[2].value = '0';
+                return;
+            }
+            return;
+        }
+        if (~hkeys.indexOf(position[0].value) && ~vkeys.indexOf(position[2].value)) {
+            position[0].value = horizontal[position[0].value];
+            position[2].value = vertical[position[2].value];
+            return;
+        } else if (~vkeys.indexOf(position[0].value) && ~hkeys.indexOf(position[2].value)) {
+            let first = position[0].value;
+            position[0].value = horizontal[position[2].value];
+            position[2].value = vertical[first];
+            return;
+        }
+    });
+    decl.value = values.toString();
+}
+
+export default plugin('cssnano-reduce-positions', () => {
+    return css => css.walkDecls(transform);
+});


### PR DESCRIPTION
This transformation works for the longhand property `background-position` and also the `background` shorthand. Conversions are as follows:

| original        | result      |
|-----------------|-------------|
| `top center`    | `top`       |
| `center top`    | `top`       |
| `top right`     | `100% 0`    |
| `top left`      | `0 0`       |
| `right`         | `100%`      |
| `right center`  | `100%`      |
| `center right`  | `100%`      |
| `right top`     | `100% 0`    |
| `right bottom`  | `100% 100%` |
| `bottom center` | `bottom`    |
| `center bottom` | `bottom`    |
| `bottom right`  | `100% 100%` |
| `bottom left`   | `0 100%`    |
| `left`          | `0`         |
| `left center`   | `0`         |
| `center left`   | `0`         |
| `left top`      | `0 0`       |
| `left bottom`   | `0 100%`    |
| `center center` | `50%`    |
| `center` | `50%`    |
| `<percentage> center` | `<percentage>` |

Relevant links:

* https://developer.mozilla.org/en-US/docs/Web/CSS/background-position
* https://developer.mozilla.org/en-US/docs/Web/CSS/position
* https://drafts.csswg.org/css-backgrounds-3/#position