### PR TITLE
Add perspective-origin to the reduce-positions transform.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Added: Reduce animation/transition timing functions. Detects `cubic-bezier`
   functions that are equivalent to the timing keywords and compresses, as well
   as normalizing the `steps` timing function.
+* Added the `perspective-origin` property to the list of supported properties
+  transformed by the `reduce-positions` transform.
 
 * * *
 

--- a/metadata.json
+++ b/metadata.json
@@ -199,8 +199,8 @@
     "source": "https://github.com/ben-eb/postcss-zindex"
   }, {
     "name": "reduce-positions",
-    "shortDescription": "Normalizes background-position definitions",
-    "longDescription": "Normalizes background position in the `background` shorthand and `background-position` properties.",
+    "shortDescription": "Normalizes CSS position definitions",
+    "longDescription": "Normalizes `position` values in the `background`, `background-position`, `-webkit-perspective-origin` and `perspective-origin` properties.",
     "inputExample": ".box {\n    background: 30% center / 50% 50%;\n}",
     "outputExample": ".box {\n    background: 30% / 50% 50%;\n}",
     "source": "https://github.com/ben-eb/cssnano/blob/master/src/lib/reducePositions.js"

--- a/src/__tests__/modules/cssnano-reduce-positions.js
+++ b/src/__tests__/modules/cssnano-reduce-positions.js
@@ -28,6 +28,14 @@ const decls = [{
     property: 'background:',
     additional: '#000 url(cat.jpg) ',
     tail: ''
+}, {
+    property: 'perspective-origin:',
+    additional: '',
+    tail: ''
+}, {
+    property: '-webkit-perspective-origin:',
+    additional: '',
+    tail: ''
 }];
 
 decls.forEach(({additional, property, tail}) => {

--- a/src/lib/reducePositions.js
+++ b/src/lib/reducePositions.js
@@ -4,7 +4,9 @@ import valueParser, {unit} from 'postcss-value-parser';
 const directions = ['top', 'right', 'bottom', 'left', 'center'];
 const properties = [
     'background',
-    'background-position'
+    'background-position',
+    '-webkit-perspective-origin',
+    'perspective-origin',
 ];
 
 const center = '50%';


### PR DESCRIPTION
Further reading:

* https://developer.mozilla.org/en-US/docs/Web/CSS/perspective-origin
* https://developer.mozilla.org/en-US/docs/Web/CSS/position_value

Something to note for the future - we can do this transform in the `transform-origin` property also, however the logic is a bit different. We'll need to refactor how the tests work in order to make sure it works properly. See https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin.