### PR TITLE
Added: Reduce background-repeat definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Head
+
+* Added: Reduce `background-repeat` definitions; works with both this property
+  & the `background` shorthand, and aims to compress the extended two value
+  syntax into the single value syntax.
+
+* * *
+
 # 3.6.2
 
 * Fixed an issue where cssnano would crash on `steps(1)`.

--- a/metadata.json
+++ b/metadata.json
@@ -198,6 +198,13 @@
     "safe": false,
     "source": "https://github.com/ben-eb/postcss-zindex"
   }, {
+    "name": "reduce-background-repeat",
+    "shortDescription": "Normalizes background repeat definitions",
+    "longDescription": "Reduces the two value syntax for `background-repeat` into the single value syntax where possible, in both the property itself and the `background` shorthand.",
+    "inputExample": ".box {\n    background-repeat: no-repeat repeat;\n}",
+    "outputExample": ".box {\n    background-repeat: repeat-y;\n}",
+    "source": "https://github.com/ben-eb/cssnano/blob/master/src/lib/reduceBackgroundRepeat.js"
+  }, {
     "name": "reduce-positions",
     "shortDescription": "Normalizes CSS position definitions",
     "longDescription": "Normalizes `position` values in the `background`, `background-position`, `-webkit-perspective-origin` and `perspective-origin` properties.",

--- a/src/__tests__/modules/cssnano-reduce-background-repeat.js
+++ b/src/__tests__/modules/cssnano-reduce-background-repeat.js
@@ -1,0 +1,29 @@
+const tests = [{
+    message: 'should pass through two value syntax',
+    fixture: 'background:space round',
+    expected: 'background:space round'
+}];
+
+const mappings = {
+    'repeat-x': 'repeat no-repeat',
+    'repeat-y': 'no-repeat repeat',
+    repeat: 'repeat repeat',
+    space: 'space space',
+    round: 'round round',
+    'no-repeat': 'no-repeat no-repeat',
+};
+
+Object.keys(mappings).forEach(mapping => {
+    tests.push({
+        message: `should handle ${mapping} (background)`,
+        fixture: `background:#000 url(cat.jpg) ${mappings[mapping]} 50%`,
+        expected: `background:#000 url(cat.jpg) ${mapping} 50%`
+    }, {
+        message: `should handle ${mapping} (background-repeat)`,
+        fixture: `background-repeat:${mappings[mapping]}`,
+        expected: `background-repeat:${mapping}`
+    });
+});
+
+module.exports.name = 'cssnano/reduce-timing-functions';
+module.exports.tests = tests;

--- a/src/__tests__/modules/cssnano-reduce-background-repeat.js
+++ b/src/__tests__/modules/cssnano-reduce-background-repeat.js
@@ -25,5 +25,5 @@ Object.keys(mappings).forEach(mapping => {
     });
 });
 
-module.exports.name = 'cssnano/reduce-timing-functions';
+module.exports.name = 'cssnano/reduce-background-repeat';
 module.exports.tests = tests;

--- a/src/__tests__/modules/cssnano-reduce-background-repeat.js
+++ b/src/__tests__/modules/cssnano-reduce-background-repeat.js
@@ -22,6 +22,14 @@ Object.keys(mappings).forEach(mapping => {
         message: `should handle ${mapping} (background-repeat)`,
         fixture: `background-repeat:${mappings[mapping]}`,
         expected: `background-repeat:${mapping}`
+    }, {
+        message: `should handle multiple instances (background)`,
+        fixture: `background-repeat:#000 url(cat.jpg) ${mappings[mapping]} 50%,#000 url(cat.jpg) ${mappings[mapping]} 50%`,
+        expected: `background-repeat:#000 url(cat.jpg) ${mapping} 50%,#000 url(cat.jpg) ${mapping} 50%`
+    }, {
+        message: `should handle multiple instances (background-repeat)`,
+        fixture: `background-repeat:${mappings[mapping]},${mappings[mapping]}`,
+        expected: `background-repeat:${mapping},${mapping}`
     });
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ import postcssDiscardUnused from 'postcss-discard-unused';
 import postcssNormalizeUrl from 'postcss-normalize-url';
 import functionOptimiser from './lib/functionOptimiser';
 import filterOptimiser from './lib/filterOptimiser';
+import reduceBackgroundRepeat from './lib/reduceBackgroundRepeat';
 import reducePositions from './lib/reducePositions';
 import core from './lib/core';
 import reduceTimingFunctions from './lib/reduceTimingFunctions';
@@ -62,6 +63,7 @@ let processors = {
     postcssNormalizeUrl,
     functionOptimiser,
     filterOptimiser,
+    reduceBackgroundRepeat,
     reducePositions,
     core,
     // Optimisations after this are sensitive to previous optimisations in

--- a/src/lib/getArguments.js
+++ b/src/lib/getArguments.js
@@ -1,0 +1,10 @@
+export default function getArguments (node) {
+    return node.nodes.reduce((list, child) => {
+        if (child.type !== 'div') {
+            list[list.length - 1].push(child);
+        } else {
+            list.push([]);
+        }
+        return list;
+    }, [[]]);
+}

--- a/src/lib/getMatch.js
+++ b/src/lib/getMatch.js
@@ -1,0 +1,7 @@
+export default function getMatchFactory (mappings) {
+    return function getMatch (args) {
+        return args.reduce((list, arg, i) => {
+            return list.filter(keyword => keyword[1][i] === arg);
+        }, mappings);
+    };
+}

--- a/src/lib/reduceBackgroundRepeat.js
+++ b/src/lib/reduceBackgroundRepeat.js
@@ -1,0 +1,74 @@
+import {plugin} from 'postcss';
+import valueParser from 'postcss-value-parser';
+import getArguments from './getArguments';
+import getMatchFactory from './getMatch';
+
+const mappings = [
+    ['repeat-x',  ['repeat', 'no-repeat']],
+    ['repeat-y',  ['no-repeat', 'repeat']],
+    ['repeat',    ['repeat', 'repeat']],
+    ['space',     ['space', 'space']],
+    ['round',     ['round', 'round']],
+    ['no-repeat', ['no-repeat', 'no-repeat']],
+];
+
+const repeat = [
+    'repeat-x',
+    'repeat-y',
+    'repeat',
+    'space',
+    'round',
+    'no-repeat',
+];
+
+const getMatch = getMatchFactory(mappings);
+
+function transform (decl) {
+    const values = valueParser(decl.value);
+    const args = getArguments(values);
+    const relevant = [];
+    args.forEach(arg => {
+        relevant.push({
+            start: null,
+            end: null
+        });
+        arg.forEach((part, index) => {
+            const isRepeat = ~repeat.indexOf(part.value);
+            const len = relevant.length - 1;
+            if (relevant[len].start === null && isRepeat) {
+                relevant[len].start = index;
+                relevant[len].end = index;
+                return;
+            }
+            if (relevant[len].start !== null) {
+                if (part.type === 'space') {
+                    return;
+                } else if (isRepeat) {
+                    relevant[len].end = index;
+                    return;
+                }
+                return;
+            }
+        });
+    });
+    relevant.forEach((range, index) => {
+        if (range.start === null) {
+            return;
+        }
+        const val = args[index].slice(range.start, range.end + 1);
+        if (val.length !== 3) {
+            return;
+        }
+        const match = getMatch(val.filter((list, i) => i % 2 === 0).map(n => n.value));
+        if (match.length) {
+            args[index][range.start].value = match[0][0];
+            args[index][range.start + 1].value = '';
+            args[index][range.end].value = '';
+        }
+    });
+    decl.value = values.toString();
+}
+
+export default plugin('cssnano-reduce-background-repeat', () => {
+    return css => css.walkDecls(/background(-repeat|$)/, transform);
+});

--- a/src/lib/reducePositions.js
+++ b/src/lib/reducePositions.js
@@ -1,5 +1,6 @@
 import {plugin} from 'postcss';
 import valueParser, {unit} from 'postcss-value-parser';
+import getArguments from './getArguments';
 
 const directions = ['top', 'right', 'bottom', 'left', 'center'];
 const properties = [
@@ -23,17 +24,6 @@ const vertical = {
 
 const hkeys = Object.keys(horizontal);
 const vkeys = Object.keys(vertical);
-
-function getArguments (node) {
-    return node.nodes.reduce((list, child) => {
-        if (child.type !== 'div') {
-            list[list.length - 1].push(child);
-        } else {
-            list.push([]);
-        }
-        return list;
-    }, [[]]);
-}
 
 function transform (decl) {
     if (!~properties.indexOf(decl.prop)) {

--- a/src/lib/reduceTimingFunctions.js
+++ b/src/lib/reduceTimingFunctions.js
@@ -1,5 +1,6 @@
 import {plugin} from 'postcss';
 import valueParser from 'postcss-value-parser';
+import getMatchFactory from './getMatch';
 
 const keywords = [
     ['ease',        [0.25, 0.1, 0.25, 1]],
@@ -11,12 +12,7 @@ const keywords = [
 
 const getArguments = (list, index) => index % 2 === 0;
 const getValue = (node) => parseFloat(node.value);
-
-function getMatch (args) {
-    return args.reduce((list, arg, i) => {
-        return list.filter(keyword => keyword[1][i] === arg);
-    }, keywords);
-}
+const getMatch = getMatchFactory(keywords);
 
 function reduce (node) {
     if (node.type !== 'function') {


### PR DESCRIPTION
### How can I help review?

I need this to be tested on real-world CSS files to ensure that no breakages occur.

### What is this?

This is a simple transform to reduce `background-repeat` definitions both in the `background` shorthand property and the `background-repeat` property.

### Example input

```css
.box {
  background-repeat: repeat no-repeat;
}
```

### Example output

```css
.box {
  background-repeat: repeat-x;
}
```

### Implementation description

This code builds on the functionality from the `reduce-positions` transform and so a lot of code looks fairly similar. It might be worthwhile to consolidate some of these transformation functions in future releases, but for now I think this is good as is.

### Transformation safety

I consider this to be a safe transform as it is converting the two value syntax to the single value syntax, *where possible*, as defined in the specification.

### External resources

* MDN: https://developer.mozilla.org/en/docs/Web/CSS/background-repeat
* Specification: https://drafts.csswg.org/css-backgrounds-3/#the-background-repeat