### PR TITLE
fixed safe option not persisting for multiple files

### DIFF
--- a/src/__tests__/api.js
+++ b/src/__tests__/api.js
@@ -63,6 +63,21 @@ ava('should not fail when options.safe is enabled', t => {
     });
 });
 
+ava('should not fail second time when the same options are passed in, with options.safe as enabled', t => {
+    const css = 'h1 { z-index: 100 }';
+    const min = 'h1{z-index:100}';
+    const options = {safe: true};
+
+    return nano.process(css, options)
+        .then(result => {
+            t.deepEqual(result.css, min, specName('beConsumedByPostCSS'));
+        })
+        .then(() => nano.process(css, options))
+        .then(result => {
+            t.deepEqual(result.css, min, specName('beConsumedByPostCSS'));
+        });
+});
+
 ava('should work with sourcemaps', t => {
     return nano.process('h1{z-index:1}', {map: {inline: true}}).then(({css}) => {
         const hasMap = /sourceMappingURL=data:application\/json;base64/.test(css);

--- a/src/index.js
+++ b/src/index.js
@@ -119,9 +119,12 @@ let safeOptions = {
 
 const cssnano = postcss.plugin('cssnano', (options = {}) => {
     // Prevent PostCSS from throwing when safe is defined
-    const safe = options.safe === true;
-    options.safe = null;
+    if (options.safe === true) {
+        options.isSafe = true;
+        options.safe = null;
+    }
 
+    const safe = options.isSafe;
     const proc = postcss();
 
     if (typeof options.fontFamily !== 'undefined' || typeof options.minifyFontWeight !== 'undefined') {


### PR DESCRIPTION
When processing multiple files with safe flag set as true, the first time it will set the safe options as null due to PostCSS throwing an error if passed in. This then means the following files will not process with the safe flag as enabled. Instead it will now set isSafe as true on the options config for the next processed files to persist the the safe option.

Fix for issue: #268
