### PR TITLE
`inline list-item` -> `inline-list-item`

### DIFF
--- a/src/lib/reduceDisplayValues.js
+++ b/src/lib/reduceDisplayValues.js
@@ -14,7 +14,7 @@ const mappings = [
     ['inline-block', ['inline', 'flow-root']],
     ['run-in', ['run-in', 'flow']],
     ['list-item', ['list-item', 'block', 'flow']],
-    ['inline list-item', ['list-item', 'inline', 'flow']],
+    ['inline-list-item', ['list-item', 'inline', 'flow']],
     ['flex', ['block', 'flex']],
     ['inline-flex', ['inline', 'flex']],
     ['grid', ['block', 'grid']],


### PR DESCRIPTION
Seems to be a typo. The tests are based on the mappings in this file, so it was uncaught. This is per the CSS3 display module spec:

https://drafts.csswg.org/css-display/#the-display-properties