### PR TITLE
Add a global browsers option.

### DIFF
--- a/docs/content/options.md
+++ b/docs/content/options.md
@@ -7,6 +7,22 @@ layout: BasicPage
 
 See the [optimisations](/optimisations/) section.
 
+## options.browsers (array|string)
+
+Set a browser scope which will be used by cssnano to determine which
+optimisations are safe to perform, using [browserslist]. You can use this option
+to set browser requirements for all optimisations at once.
+
+If you don't set this option, then [browserslist] will try to find one from
+a config file, entry in `package.json`, environment variables or will load
+its defaults if it can't find anything.
+
+*Note that this is a new feature since version `3.10.0` and so support for it is
+limited to `autoprefixer` right now. Better support for this option is planned
+for version `4.0.0`.*
+
+[browserslist]: https://github.com/ai/browserslist#readme
+
 ## options.safe (bool)
 
 Set this to `true` to disable advanced optimisations that are not always safe.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "^6.3.1",
+    "browserslist": "^1.5.1",
     "decamelize": "^1.1.2",
     "defined": "^1.0.0",
     "has": "^1.0.1",

--- a/src/__tests__/api.js
+++ b/src/__tests__/api.js
@@ -88,3 +88,19 @@ ava('should work with sourcemaps (2)', t => {
         t.truthy(hasMap);
     });
 });
+
+ava(
+    'should have a global browsers option',
+    processCss,
+    'h1{border-radius:10px}',
+    'h1{-webkit-border-radius:10px;-moz-border-radius:10px;border-radius:10px}',
+    {browsers: ['> 0%'], autoprefixer: {add: true}}
+);
+
+ava(
+    'should work with browsers set in autoprefixer',
+    processCss,
+    'h1{border-radius:10px}',
+    'h1{-webkit-border-radius:10px;-moz-border-radius:10px;border-radius:10px}',
+    {autoprefixer: {add: true, browsers: ['> 0%']}}
+);

--- a/src/__tests__/modules/autoprefixer.js
+++ b/src/__tests__/modules/autoprefixer.js
@@ -7,7 +7,7 @@ module.exports.tests = [{
     message: 'should not remove outdated vendor prefixes when minifying for older browsers',
     fixture: 'h1{-webkit-box-sizing:content-box;box-sizing:content-box}',
     expected: 'h1{-webkit-box-sizing:content-box;box-sizing:content-box}',
-    options: {autoprefixer: {browsers: 'Safari < 5'}},
+    options: {browsers: 'Safari < 5'},
 }, {
     message: 'should not remove outdated vendor prefixes if disabled',
     fixture: 'h1{-webkit-box-sizing:content-box;box-sizing:content-box}',

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import browserslist from 'browserslist';
 import decamelize from 'decamelize';
 import defined from 'defined';
 import assign from 'object-assign';
@@ -130,6 +131,7 @@ const cssnano = postcss.plugin('cssnano', (options = {}) => {
 
     const safe = options.isSafe;
     const proc = postcss();
+    const browsers = browserslist(options.browsers);
 
     if (typeof options.fontFamily !== 'undefined' || typeof options.minifyFontWeight !== 'undefined') {
         warnOnce('The fontFamily & minifyFontWeight options have been ' +
@@ -162,6 +164,7 @@ const cssnano = postcss.plugin('cssnano', (options = {}) => {
         opts = assign({},
             defaultOptions[plugin],
             safe ? safeOptions[plugin] : null,
+            {browsers},
             opts
         );
 


### PR DESCRIPTION
Ref: https://github.com/ben-eb/cssnano/issues/297

@ai What do you think of this implementation? This sets the stage for each optimisation to take a list of supported browsers, then they can use caniuse-db if they need to provide different logic for different browser versions.