### PR TITLE
Fix resolveConfig for Root without source

### DIFF
--- a/packages/cssnano/src/index.js
+++ b/packages/cssnano/src/index.js
@@ -31,7 +31,7 @@ function initializePlugin (plugin, css, result) {
 }
 
 function fromFile (css, result) {
-    const filePath = css.source.input && css.source.input.file || process.cwd();
+    const filePath = css.source && css.source.input && css.source.input.file || process.cwd();
     result.messages.push({
         type: 'debug',
         plugin: cssnano,


### PR DESCRIPTION
`fromFile` was trying to access the `Root` nodes `source` property, which is not always set (for example when creating it with `postcss.root()`.

This just adds an additional check for `css.source` in `fromFile`.