### PR TITLE
Speed up CI builds by caching development dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ sudo: false
 
 language: node_js
 node_js:
-  - "7"
-  - "6"
-  - "5"
-  - "4"
+  - 7
+  - 6
+  - 5
+  - 4
+
 env:
   - CXX=g++-4.8
 addons:
@@ -15,5 +16,14 @@ addons:
     packages:
       - g++-4.8
 
+install:
+  - npm update
+  - npm run postinstall
+  - npm prune
+
+cache:
+  directories:
+    - node_modules
+
 after_success:
-  - './node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls'
+  - npm run ci

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "report": "nyc report --reporter=html",
     "postinstall": "lerna bootstrap",
     "pretest": "eslint --ignore-path .gitignore packages/**/src util",
-    "test": "cross-env BABEL_ENV=test nyc ava"
+    "test": "cross-env BABEL_ENV=test nyc ava",
+    "ci": "nyc report --reporter=text-lcov | coveralls"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Speed up CI by caching the development dependencies. The 1st run is uncached then the 2nd and 3rd are cached, timings are in seconds. A lot of fluctuations but overall except from the bold outlier it's an improvement.

Run | Node 4 | Node 5 | Node 6 | Node 7
----- | --------- | -------- | --------- | ----------
[1st](https://travis-ci.org/ben-eb/cssnano/builds/253924950) | 628 | 184 | 330 | 159
[2nd](https://travis-ci.org/ben-eb/cssnano/builds/253930585) | 196 | 139 | 142 | **266**
[3rd](https://travis-ci.org/ben-eb/cssnano/builds/253936063) | 367 | 126 | 279 | 118