### PR TITLE
Fix CI module caching for npm versions older than 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ addons:
       - g++-4.8
 
 install:
-  - npm update
-  - npm run postinstall
+  - npm install
   - npm prune
 
 cache:


### PR DESCRIPTION
As of npm@2.6.1, the npm update will only inspect top-level packages.
Prior versions of npm would also recursively inspect all dependencies.
The old recursive behaviour causes version mismatches.

See https://github.com/ben-eb/cssnano/pull/388#issuecomment-315902885 for more context.