### PR TITLE
Preserve invalid input on border ordered values -  fixes #402

### DIFF
--- a/packages/postcss-ordered-values/src/__tests__/index.js
+++ b/packages/postcss-ordered-values/src/__tests__/index.js
@@ -19,6 +19,20 @@ test(
 );
 
 test(
+    'should preserve unknown values in border with order',
+    processCSS,
+    'h1{border:"unknown1" 1px "unknown2"}',
+    'h1{border:1px "unknown1" "unknown2"}'
+);
+
+test(
+    'should preserve unknown values in border with order with two properties',
+    processCSS,
+    'h1{border:solid "unknown1"}',
+    'h1{border:"unknown1" solid}'
+);
+
+test(
     'should order border with color functions',
     processCSS,
     'h1{border:rgba(255,255,255,0.5) dashed thick}',

--- a/packages/postcss-ordered-values/src/rules/border.js
+++ b/packages/postcss-ordered-values/src/rules/border.js
@@ -48,5 +48,31 @@ export default function normalizeBorder (decl, border) {
             return false;
         }
     });
-    decl.value = `${order.width} ${order.style} ${order.color}`.trim();
+
+    const parts = getBorderParts(border, decl.value);
+    const {width, style, color} = mergeWithInitialBorderParts(parts, order);
+    decl.value = `${width} ${style} ${color}`.trim();
 };
+
+function mergeWithInitialBorderParts (parts, order) {
+    const orderedValues = ['width', 'style', 'color'].map((key) => order[key]);
+    const diff = parts.filter((part) => orderedValues.indexOf(part) === -1);
+    const [width='', style='', color=''] = orderedValues.map((val) => val ? val : diff.shift());
+
+    return {width, style, color};
+}
+
+function getBorderParts (border, originalValue) {
+    const borderParts = [];
+    let lastIndex = 0;
+    border.walk(node => {
+        if (node.type === 'space') {
+            borderParts.push(originalValue.substring(lastIndex, node.sourceIndex));
+            lastIndex = node.sourceIndex + 1;
+        }
+    });
+
+    borderParts.push(originalValue.substring(lastIndex));
+
+    return borderParts;
+}


### PR DESCRIPTION
Given invalid values to border, ordered-values should not remove them.