### PR TITLE
Don't remove quotes from font-family by default

### DIFF
--- a/packages/postcss-minify-font-values/src/index.js
+++ b/packages/postcss-minify-font-values/src/index.js
@@ -25,7 +25,7 @@ export default postcss.plugin('postcss-minify-font-values', (opts) => {
     opts = Object.assign({}, {
         removeAfterKeyword: false,
         removeDuplicates: true,
-        removeQuotes: true,
+        removeQuotes: false,
     }, opts);
 
     return css => css.walkDecls(/font/i, transform.bind(null, opts));


### PR DESCRIPTION
This can cause "invalid property value" for certain font stacks. Closes #434 #430