### PR TITLE
fix: don't remove `all` for ie 10 and 11

### DIFF
--- a/packages/postcss-minify-params/package.json
+++ b/packages/postcss-minify-params/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.0.0",
+    "browserslist": "^2.0.0",
     "cross-env": "^3.0.0"
   },
   "engines": {

--- a/packages/postcss-minify-params/src/__tests__/index.js
+++ b/packages/postcss-minify-params/src/__tests__/index.js
@@ -22,7 +22,16 @@ test(
     'should normalise "all" in @media queries',
     processCSS,
     '@media all{h1{color:blue}}',
-    '@media{h1{color:blue}}'
+    '@media{h1{color:blue}}',
+    {env: 'chrome58'}
+);
+
+test(
+    'should not normalise "all" in @media queries',
+    processCSS,
+    '@media all{h1{color:blue}}',
+    '@media all{h1{color:blue}}',
+    {env: 'ie11'}
 );
 
 test(

--- a/packages/postcss-minify-params/yarn.lock
+++ b/packages/postcss-minify-params/yarn.lock
@@ -275,6 +275,17 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+browserslist@^2.0.0:
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
+  dependencies:
+    caniuse-lite "^1.0.30000792"
+    electron-to-chromium "^1.3.30"
+
+caniuse-lite@^1.0.30000792:
+  version "1.0.30000821"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000821.tgz#0f3223f1e048ed96451c56ca6cf197058c42cb93"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -416,6 +427,10 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+electron-to-chromium@^1.3.30:
+  version "1.3.41"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.41.tgz#7e33643e00cd85edfd17e04194f6d00e73737235"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
fixes #432
IE 10 also have this bug, but 
```css
@media all and (min-width:500px){h1{color:blue}}
@media (min-width:500px){h1{color:blue}}
```
works fine in IE 10 and IE 11