### PR TITLE
chore(postcss-filter-plugins): Fix vulnerable downstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "postcss-discard-empty": "^2.0.1",
     "postcss-discard-overridden": "^0.1.1",
     "postcss-discard-unused": "^2.2.1",
-    "postcss-filter-plugins": "^2.0.0",
+    "postcss-filter-plugins": "^2.0.3",
     "postcss-merge-idents": "^2.1.5",
     "postcss-merge-longhand": "^2.0.1",
     "postcss-merge-rules": "^2.0.3",


### PR DESCRIPTION
https://github.com/postcss/postcss-filter-plugins/commit/86501b247fc33dd1386033111aacbf3e43fa148b

I've checked out a separate branch from the commit of `3.10.0` version. So you should be able to publish an update from this branch to `3.10.1`. Thanks!